### PR TITLE
Fix error when including a Pad layer

### DIFF
--- a/src/armnn/InternalTypes.cpp
+++ b/src/armnn/InternalTypes.cpp
@@ -36,6 +36,7 @@ char const* GetLayerTypeAsCString(LayerType type)
         case LayerType::Multiplication: return "Multiplication";
         case LayerType::Normalization: return "Normalization";
         case LayerType::Output: return "Output";
+        case LayerType::Pad: return "Pad";
         case LayerType::Permute: return "Permute";
         case LayerType::Pooling2d: return "Pooling2d";
         case LayerType::Reshape: return "Reshape";


### PR DESCRIPTION
Missing case in 'GetLayerTypeAsCString' function