### PR TITLE
update field name of serialized format not to make problem with js

### DIFF
--- a/src/armnnDeserializer/Deserializer.cpp
+++ b/src/armnnDeserializer/Deserializer.cpp
@@ -866,7 +866,7 @@ void Deserializer::ParseActivation(GraphPtr graph, unsigned int layerIndex)
     auto serializerDescriptor = serializerLayer->descriptor();
 
     armnn::ActivationDescriptor descriptor;
-    descriptor.m_Function = ToActivationFunction(serializerDescriptor->function());
+    descriptor.m_Function = ToActivationFunction(serializerDescriptor->activationFunction());
     descriptor.m_A = serializerDescriptor->a();
     descriptor.m_B = serializerDescriptor->b();
 

--- a/src/armnnSerializer/ArmnnSchema.fbs
+++ b/src/armnnSerializer/ArmnnSchema.fbs
@@ -156,7 +156,7 @@ table ActivationLayer {
 }
 
 table ActivationDescriptor {
-    function:ActivationFunction = Sigmoid;
+    activationFunction:ActivationFunction = Sigmoid;
     a:float;
     b:float;
 }


### PR DESCRIPTION
I tried to make a patch for Netron to support ArmNN serialized format, but compiled ArmNN serialization scheme in JS language was not working because ArmNN serialization scheme uses 'function' as field name which is keyword in javascript.

So I changed the field name to 'activationFunction' (I considered to changing it to 'func' but since 'func' is keyword in python, so I thought 'activationFunction' is better.)

As in Flatbuffer's guide, renaming field name can brake codes, but ArmNN serializer does not use text format such as json, and guide said that changing field name does not brake actual binary format. So patched version will be working previously generated files either.

```Occasionally ok. You've renamed fields, which will break all code (and JSON files!) that use this schema, but as long as the change is obvious, this is not incompatible with the actual binary buffers, since those only ever address fields by id/offset.```