### PR TITLE
update field name of serialized format not to make problem with js

### DIFF
--- a/src/armnnDeserializer/Deserializer.cpp
+++ b/src/armnnDeserializer/Deserializer.cpp
@@ -910,7 +910,7 @@ void Deserializer::ParseActivation(GraphPtr graph, unsigned int layerIndex)
     auto serializerDescriptor = serializerLayer->descriptor();
 
     armnn::ActivationDescriptor descriptor;
-    descriptor.m_Function = ToActivationFunction(serializerDescriptor->function());
+    descriptor.m_Function = ToActivationFunction(serializerDescriptor->activationFunction());
     descriptor.m_A = serializerDescriptor->a();
     descriptor.m_B = serializerDescriptor->b();
 
@@ -957,7 +957,7 @@ void Deserializer::ParseArgMinMax(GraphPtr graph, unsigned int layerIndex)
     auto serializerDescriptor = serializerLayer->descriptor();
 
     armnn::ArgMinMaxDescriptor descriptor;
-    descriptor.m_Function = ToArgMinMaxFunction(serializerDescriptor->function());
+    descriptor.m_Function = ToArgMinMaxFunction(serializerDescriptor->argMinMaxFunction());
     descriptor.m_Axis = serializerDescriptor->axis();
     auto layerName = GetLayerName(graph, layerIndex);
     IConnectableLayer* layer = m_Network->AddArgMinMaxLayer(descriptor, layerName.c_str());

--- a/src/armnnSerializer/ArmnnSchema.fbs
+++ b/src/armnnSerializer/ArmnnSchema.fbs
@@ -170,7 +170,7 @@ table ActivationLayer {
 }
 
 table ActivationDescriptor {
-    function:ActivationFunction = Sigmoid;
+    activationFunction:ActivationFunction = Sigmoid;
     a:float;
     b:float;
 }
@@ -185,7 +185,7 @@ table ArgMinMaxLayer {
 }
 
 table ArgMinMaxDescriptor{
-    function:ArgMinMaxFunction;
+    argMinMaxFunction:ArgMinMaxFunction;
     axis:int;
 }
 


### PR DESCRIPTION
I tried to make a patch for Netron to support ArmNN serialized format, but compiled ArmNN serialization scheme in JS language was not working because ArmNN serialization scheme uses 'function' as field name which is keyword in javascript.

So I changed the field name to 'activationFunction' (I considered to changing it to 'func' but since 'func' is keyword in python, so I thought 'activationFunction' is better.)

As in Flatbuffer's guide, renaming field name can brake codes, but ArmNN serializer does not use text format such as json, and guide said that changing field name does not brake actual binary format. So patched version will be working previously generated files either.

```Occasionally ok. You've renamed fields, which will break all code (and JSON files!) that use this schema, but as long as the change is obvious, this is not incompatible with the actual binary buffers, since those only ever address fields by id/offset.```