### PR TITLE
Add argmax deconv support for caffe parser

### DIFF
--- a/src/armnnCaffeParser/CaffeParser.hpp
+++ b/src/armnnCaffeParser/CaffeParser.hpp
@@ -56,6 +56,7 @@ protected:
     /// @{
     void ParseInputLayer(const caffe::LayerParameter& layerParam);
     void ParseConvLayer(const caffe::LayerParameter& layerParam);
+    void ParseDeconvLayer(const caffe::LayerParameter& layerParam);
     void ParsePoolingLayer(const caffe::LayerParameter& layerParam);
     void ParseReluLayer(const caffe::LayerParameter& layerParam);
     void ParseLRNLayer(const caffe::LayerParameter& layerParam);
@@ -67,6 +68,7 @@ protected:
     void ParseScaleLayer(const caffe::LayerParameter& layerParam);
     void ParseSplitLayer(const caffe::LayerParameter& layerParam);
     void ParseDropoutLayer(const caffe::LayerParameter& layerParam);
+    void ParseArgmaxLayer(const caffe::LayerParameter& layerParam);
     /// @}
 
     /// ParseConv may use these helpers depending on the group parameter
@@ -79,6 +81,10 @@ protected:
                                        const armnn::Convolution2dDescriptor & desc,
                                        unsigned int kernelW,
                                        unsigned int kernelH);
+    void AddDeconvLayerWithSplits(const caffe::LayerParameter& layerParam,
+                                const armnn::TransposeConvolution2dDescriptor& desc,
+                                unsigned int kernelW,
+                                unsigned int kernelH);
     /// @}
 
     /// Converts Caffe's protobuf tensor shape format to ArmNN's

--- a/src/armnnCaffeParser/CaffeSupport.md
+++ b/src/armnnCaffeParser/CaffeSupport.md
@@ -16,8 +16,10 @@ Although some other neural networks might work, Arm tests the Arm NN SDK with Ca
 The Arm NN SDK supports the following machine learning layers for Caffe networks:
 
 
+- Argmax, excluding the top_k and out_max_val parameters.
 - BatchNorm, in inference mode.
-- Convolution, excluding the Dilation Size, Weight Filler, Bias Filler, Engine, Force nd_im2col, and Axis parameters.
+- Convolution, excluding Weight Filler, Bias Filler, Engine, Force nd_im2col, and Axis parameters.
+- Deconvolution, excluding the Dilation Size, Weight Filler, Bias Filler, Engine, Force nd_im2col, and Axis parameters.
 
   Caffe doesn't support depthwise convolution, the equivalent layer is implemented through the notion of groups. ArmNN supports groups this way:
   - when group=1, it is a normal conv2d


### PR DESCRIPTION
armnn support argmax and deconv , but caffe parser does not.
Add back this feature.

Signed-off-by: Keith Mok <ek9852@gmail.com>
Change-Id: I6b99cc4b58491204c41c6e1d11f583c65c628ee4