### PR TITLE
[Bug fix] ExpandDims Segmentation fault

### DIFF
--- a/src/armnnTfLiteParser/TfLiteParser.cpp
+++ b/src/armnnTfLiteParser/TfLiteParser.cpp
@@ -1156,7 +1156,7 @@ void TfLiteParserImpl::ParseExpandDims(size_t subgraphIndex, size_t operatorInde
     }
     else
     {
-        int32_t axis = inputs[1]->shape[0];
+        int32_t axis = inputs[0]->shape[0];
 
         int32_t inputDimSize = static_cast<int32_t>(inputTensorInfo.GetShape().GetNumDimensions());
 


### PR DESCRIPTION
ExpandDims layer in TFLite caused segmentation fault while being parsed, this was fixed in the code.

Signed-off-by: Moustafa Ghareeb <moustafa.ghareeb.hpg@gmail.com>