### PR TITLE
Fix TfLiteParserImpl::GetNetworkOutputBindingInfo

### DIFF
--- a/src/armnnTfLiteParser/TfLiteParser.cpp
+++ b/src/armnnTfLiteParser/TfLiteParser.cpp
@@ -2906,6 +2906,7 @@ void TfLiteParserImpl::ParseDetectionPostProcess(size_t subgraphIndex, size_t op
 
     for (unsigned int i = 0 ; i < outputs.size() ; ++i)
     {
+        m_OverridenOutputShapesMappedByName[outputs[i]->name] = m_OverridenOutputShapes[i]; 
         armnn::TensorInfo detectionBoxOutputTensorInfo = ToTensorInfo(outputs[i], m_OverridenOutputShapes[i]);
         layer->GetOutputSlot(i).SetTensorInfo(detectionBoxOutputTensorInfo);
     }
@@ -4238,8 +4239,8 @@ BindingPointInfo TfLiteParserImpl::GetNetworkOutputBindingInfo(size_t subgraphId
         if (output.second->name == name)
         {
             auto bindingId = GenerateLayerBindingId(subgraphId, output.first);
-            std::vector<unsigned int> shape = m_OverridenOutputShapes.size() > 0 ?
-                                                m_OverridenOutputShapes[i] : AsUnsignedVector(output.second->shape);
+            std::vector<unsigned int> shape = m_OverridenOutputShapesMappedByName.empty() > 0 ?
+                                                AsUnsignedVector(output.second->shape) : m_OverridenOutputShapesMappedByName.at(name);
             return std::make_pair(bindingId, ToTensorInfo(output.second, shape));
         }
     }

--- a/src/armnnTfLiteParser/TfLiteParser.hpp
+++ b/src/armnnTfLiteParser/TfLiteParser.hpp
@@ -273,6 +273,8 @@ private:
     /// This is used in case that the model does not speciry the output.
     /// The shape can be calculated from the options.
     std::vector<std::vector<unsigned int>> m_OverridenOutputShapes;
+    std::map<std::string, std::vector<unsigned int>> m_OverridenOutputShapesMappedByName;
+
 };
 
 }


### PR DESCRIPTION
In the previous version GetNetworkOutputBindingInfo will use m_OverridenOutputShapes to get the output tensor shape. The order is got from GetSubgraphOutputs(). But this order may be different from m_OverridenOutputShapes wich is got from custom operator 'TFLite_Detection_PostProcess'. Map the outputs shape by layer name can solve this problem.
Look this issue  #585 .