### PR TITLE
Fix quick start guide example inputs

### DIFF
--- a/delegate/DelegateQuickStartGuide.md
+++ b/delegate/DelegateQuickStartGuide.md
@@ -24,7 +24,7 @@ output_details = interpreter.get_output_details()
 
 # Test model on random input data.
 input_shape = input_details[0]['shape']
-input_data = np.array(np.random.random_sample(input_shape), dtype=np.uint8)
+input_data = np.array(np.random.randint(0, 255, input_shape), dtype=np.uint8)
 interpreter.set_tensor(input_details[0]['index'], input_data)
 
 interpreter.invoke()


### PR DESCRIPTION
This PR fixes the inputs for the quickstart example. Previously random_sample would create values < 1, which would all be rounded down to zero after casting to uint8. Now, randint creates integers between 0 and 255 fall in the ranges of inputs expected by the model.