### PR TITLE
Add steps to install flatbuffers in Dockerfile.

### DIFF
--- a/build-tool/docker/Dockerfile
+++ b/build-tool/docker/Dockerfile
@@ -33,6 +33,15 @@ WORKDIR /root
 COPY ./scripts/install-packages.sh .
 RUN ./install-packages.sh
 
+RUN git clone https://github.com/google/flatbuffers.git && \
+    cd flatbuffers && \
+    cmake -G "Unix Makefiles" . && \
+    make && \
+    ./flattests && \
+    make install && \
+    ldconfig && \
+    flatc --version
+
 # Define user for non-root processes (overwriteable during 'docker build' with --build-arg)
 ARG USER_ID=1000
 ARG GROUP_ID=1000


### PR DESCRIPTION
When building using Dockerfile of armnn v23.11, there occurs an error regarding flatbuffers.
The error occurs due to absence of the module so that I added codes to install the package before the steps which requires flatbuffers.